### PR TITLE
remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,8 @@
         "commander": "^11.1.0",
         "diff": "^5.2.0",
         "dotenv": "^16.4.5",
-        "eciesjs": "^0.4.6",
         "fdir": "^6.2.0",
-        "ignore": "^5.3.0",
-        "object-treeify": "1.1.33",
         "picomatch": "^4.0.2",
-        "tinyexec": "^0.2.0",
-        "which": "^4.0.0",
         "xxhashjs": "^0.2.2"
       },
       "bin": {
@@ -554,39 +549,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@noble/ciphers": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.5.3.tgz",
-      "integrity": "sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/curves": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.5.0.tgz",
-      "integrity": "sha512-J5EKamIHnKPyClwVrzmaf5wSdQXgdHcPZIZLu3bwnbeCx8/7NPK5q2ZBWF+5FvYGByjiQQsJYX6jfgB2wDPn3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.4.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3849,20 +3811,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/eciesjs": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.7.tgz",
-      "integrity": "sha512-4JQahOkBdDy27jjW4q3FJQigHlcwZXx28sCtBQkBamF2XUdcNXrInpgrr8h205MtVIS0CMHufyIKGVjtjxQ2ZA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/ciphers": "^0.5.3",
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -5621,6 +5569,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -6415,6 +6364,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16"
@@ -7865,15 +7815,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object-treeify": {
-      "version": "1.1.33",
-      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
-      "integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/object.assign": {
@@ -10808,12 +10749,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/tinyexec": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.2.0.tgz",
-      "integrity": "sha512-au8dwv4xKSDR+Fw52csDo3wcDztPdne2oM1o/7LFro4h6bdFmvyUAeAfX40pwDtzHgRFqz1XWaUqgKS2G83/ig==",
-      "license": "MIT"
-    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -11373,6 +11308,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
       "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -31,13 +31,8 @@
     "commander": "^11.1.0",
     "diff": "^5.2.0",
     "dotenv": "^16.4.5",
-    "eciesjs": "^0.4.6",
     "fdir": "^6.2.0",
-    "ignore": "^5.3.0",
-    "object-treeify": "1.1.33",
     "picomatch": "^4.0.2",
-    "tinyexec": "^0.2.0",
-    "which": "^4.0.0",
     "xxhashjs": "^0.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
makes this extension 5x smaller in terms of bundle size :eyes:

```
Estimated new statistics:
  Package size: 5.2 MB → 1.1 MB (21.69%)
  Subdependencies: 17 → 7 (-10)
  Traffic with last week's downloads:
    For current version: 340 MB → 74 MB (266 MB saved)
    For all versions: 552 MB → 120 MB (432 MB saved)
```